### PR TITLE
docs: Fix incorrect command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm i
 First, ensure Docker is running.
 
 ```sh
-npm run db:start
+npm run docker:start
 ```
 
 Generate tables and the Prisma client.


### PR DESCRIPTION
Corrected the command from `npm run db:start` to `npm run docker:start` in the README.