### PR TITLE
fix: UI issues in layout and stakeholder table in mobile

### DIFF
--- a/src/app/(authenticated)/(onboarded)/dashboard/layout.tsx
+++ b/src/app/(authenticated)/(onboarded)/dashboard/layout.tsx
@@ -13,7 +13,7 @@ const DashboardLayout = ({ children }: DashboardLayoutProps) => {
       </aside>
       <div className="flex flex-grow flex-col lg:border-l">
         <NavBar />
-        <div className="px-4 py-6 lg:px-8 2xl:mx-auto 2xl:max-w-screen-2xl">
+        <div className="w-full px-4 py-6 lg:px-8 2xl:mx-auto 2xl:max-w-screen-2xl">
           {children}
         </div>
       </div>

--- a/src/app/(authenticated)/(onboarded)/dashboard/stakeholders/page.tsx
+++ b/src/app/(authenticated)/(onboarded)/dashboard/stakeholders/page.tsx
@@ -22,7 +22,7 @@ const StakeholdersPage = async () => {
 
   return (
     <div className="flex flex-col gap-y-3">
-      <div className="flex flex-col items-center justify-between gap-y-3 md:flex-row">
+      <div className="flex  items-center justify-between gap-y-3 ">
         <div className="gap-y-3">
           <h2 className="text-xl font-medium">Stakeholders</h2>
           <p className="text-sm text-muted-foreground">
@@ -30,7 +30,7 @@ const StakeholdersPage = async () => {
           </p>
         </div>
 
-        <div className="w-full md:w-auto">
+        <div>
           <InviteMemberModal inviteeName={session.user.name} />
         </div>
       </div>

--- a/src/components/stakeholder/member-card.tsx
+++ b/src/components/stakeholder/member-card.tsx
@@ -60,7 +60,7 @@ export function MemberCard({
   };
 
   return (
-    <div className="flex w-full flex-wrap items-center justify-between space-x-4">
+    <div className="flex w-full items-center justify-between space-x-4">
       <div className="flex items-center space-x-4">
         <Avatar>
           <AvatarImage

--- a/src/components/stakeholder/member-card.tsx
+++ b/src/components/stakeholder/member-card.tsx
@@ -60,7 +60,7 @@ export function MemberCard({
   };
 
   return (
-    <div className="flex w-full items-center justify-between space-x-4">
+    <div className="flex w-full flex-wrap items-center justify-between space-x-4">
       <div className="flex items-center space-x-4">
         <Avatar>
           <AvatarImage


### PR DESCRIPTION
fixes  #55. this PR fixes a Ui issue in layout by adding a `max-width` and fixes ui issue in stakeholder table for mobile 


desktop after:

![Screen Shot 2024-01-19 at 15 08 07](https://github.com/opencapco/opencap.co/assets/84864519/26ad7014-cec3-456d-bef3-86a30be93e5f)

mobile after:

![Screen Shot 2024-01-19 at 15 10 16](https://github.com/opencapco/opencap.co/assets/84864519/75278ad5-18fc-4e60-82e4-f970c70193b4)

